### PR TITLE
fix(android): implement openFileInExplorer for Android

### DIFF
--- a/src/androidMain/kotlin/com/nocloudchat/Platform.kt
+++ b/src/androidMain/kotlin/com/nocloudchat/Platform.kt
@@ -1,13 +1,46 @@
 package com.nocloudchat
 
 import android.content.Context
+import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.os.Environment
+import android.provider.DocumentsContract
 import java.io.File
 
 actual fun openFileInExplorer(path: String) {
-    // TODO: launch Android file manager Intent
+    runCatching {
+        val context = AppContextHolder.appContext
+        val target = File(path)
+        val directory = if (target.isDirectory) target else target.parentFile ?: target
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            val downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            if (directory.canonicalPath.startsWith(downloadDir.canonicalPath)) {
+                val relative = directory.canonicalPath.removePrefix(downloadDir.canonicalPath).trimStart('/')
+                data = DocumentsContract.buildRootUri(
+                    "com.android.externalstorage.documents",
+                    "home"
+                )
+                if (relative.isNotEmpty()) {
+                    putExtra("android.provider.extra.INITIAL_URI", DocumentsContract.buildDocumentUri(
+                        "com.android.externalstorage.documents",
+                        "home:$relative"
+                    ))
+                }
+            } else {
+                data = DocumentsContract.buildRootUri(
+                    "com.android.externalstorage.documents",
+                    "primary"
+                )
+            }
+            type = "vnd.android.document/root"
+        }
+
+        context.startActivity(intent)
+    }
 }
 
 actual fun pickFile(): java.io.File? = null // TODO: launch Android file picker Intent


### PR DESCRIPTION
### Motivation

- The Android `openFileInExplorer(path)` was a TODO stub and prevented opening received files from the app on Android devices.
- Implement a safe, platform-appropriate way to open the system document UI and prefer the Downloads/Home root when applicable.

### Description

- Replaced the TODO stub in `src/androidMain/kotlin/com/nocloudchat/Platform.kt` with an intent-based implementation that resolves the target directory and launches a documents UI using `Intent.ACTION_VIEW`.
- Added imports for `Intent`, `Environment`, and `DocumentsContract` and logic to detect if the path is under the public Downloads directory to set an initial URI via `android.provider.extra.INITIAL_URI`.
- The implementation uses `runCatching` to avoid crashing if no activity can handle the intent and leaves `pickFile()` still as a TODO.

### Testing

- Attempted to compile Kotlin with `./gradlew :compileDebugKotlin --no-daemon`, but the Gradle wrapper download was blocked by the environment proxy and returned `403 Forbidden`, so compilation could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22042a3c4832098e79bf04e43ddba)